### PR TITLE
Prepare for 0.6.0 release in Foxy.

### DIFF
--- a/tracks.yaml
+++ b/tracks.yaml
@@ -62,7 +62,7 @@ tracks:
       -i :{release_inc} --os-name debian --os-not-required
     - git-bloom-generate -y rosrpm --prefix release/:{ros_distro} :{ros_distro} -i
       :{release_inc}
-    devel_branch: master
+    devel_branch: releases/0.6.x
     last_release: 004932817e111597db65e6b332f92ae9bbe9fe30
     last_version: 0.5.1
     name: cyclonedds

--- a/tracks.yaml
+++ b/tracks.yaml
@@ -53,7 +53,7 @@ tracks:
     actions:
     - bloom-export-upstream :{vcs_local_uri} :{vcs_type} --tag :{release_tag} --display-uri
       :{vcs_uri} --name :{name} --output-dir :{archive_dir_path}
-    - git-bloom-import-upstream :{archive_path} :{patches} --release-version 0.5.1+osrf1@g0049328
+    - git-bloom-import-upstream :{archive_path} :{patches} --release-version :{version}
       --replace
     - git-bloom-generate -y rosrelease :{ros_distro} --source upstream -i :{release_inc}
     - git-bloom-generate -y rosdebian --prefix release/:{ros_distro} :{ros_distro}
@@ -69,8 +69,8 @@ tracks:
     patches: null
     release_inc: '2'
     release_repo_url: https://github.com/ros2-gbp/cyclonedds-release.git
-    release_tag: 004932817e111597db65e6b332f92ae9bbe9fe30
+    release_tag: :{version}
     ros_distro: foxy
     vcs_type: git
     vcs_uri: https://github.com/eclipse-cyclonedds/cyclonedds.git
-    version: 0.5.1
+    version: 0.6.0


### PR DESCRIPTION
When preparing the Foxy release we released a pinned commit of  CycloneDDS as 0.5.1+osrf1@g0049328, which renders as the ROS version 0.5.1, while waiting for a 0.6.x release candidate. Now that the candidate is available (and indeed the 0.6.0 release is now official!) we can drop the custom version and release_tag in favor of 0.6.0.
