### PR TITLE
Add idlc dependencies to release package.xml.

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -13,6 +13,8 @@
     <url type="repository">https://github.com/eclipse-cyclonedds/cyclonedds</url>
 
     <buildtool_depend>cmake</buildtool_depend>
+    <buildtool_depend>java</buildtool_depend>
+    <buildtool_depend>maven</buildtool_depend>
 
     <depend>openssl</depend>
     <test_depend>libcunit-dev</test_depend>


### PR DESCRIPTION
Changes to the bloom template wiped out our patches to the debian release branches. As a result the idlc is currently enabled but failing to build without maven.

I believe https://github.com/ros2-gbp/cyclonedds-release/commit/f470706caad46bd02acf3e386baff894b2ca100f was the first commit to enable building the idlc for Eloquent. Making the change to the release package.xml should enable idlc builds for everyone building cyclonedds from source as well as making sure the dependencies for the idlc are injected into the debian build environment (since they'll be resolved as rosdep keys).

I think there was an intention previously to avoid this dependency when not building for the debian packages however since the idlc is built by default and turning it off requires a CMake define. Someone building from this release branch using rosdep would have gotten the same failure to build the idlc due to maven being missing.

After this is merged `bloom-release -r eloquent cyclonedds` should create a package revision that builds on the buildfarm.

For Dashing I directly applied a change that just disables the idlc build again since performance jobs don't run for Dashing.