### PR TITLE
Add idlc dependencies to release package.xml.

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -13,6 +13,8 @@
     <url type="repository">https://github.com/eclipse-cyclonedds/cyclonedds</url>
 
     <buildtool_depend>cmake</buildtool_depend>
+    <buildtool_depend>java</buildtool_depend>
+    <buildtool_depend>maven</buildtool_depend>
 
     <depend>openssl</depend>
     <test_depend>libcunit-dev</test_depend>


### PR DESCRIPTION
Adding this solely to the debian branches to preserve the existing
behavior of not building idlc / depending on java / maven in from-source
builds.

This is an alternative to #6 which is in closer-keeping with the previous behavior.